### PR TITLE
KMK simple example, only 1 row works

### DIFF
--- a/code.py
+++ b/code.py
@@ -1,0 +1,21 @@
+print ("Starting")
+
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.keys import KC
+from kmk.scanners import DiodeOrientation
+
+keyboard = KMKKeyboard()
+
+keyboard.row_pins = (board.GP13, board.GP15)
+keyboard.col_pins = (board.GP16, board.GP17)
+keyboard.diode_orientation = DiodeOrientation.COL2ROW
+
+keyboard.keymap = [
+    [KC.A, KC.B],
+    [KC.C, KC.D]
+]
+
+if __name__ == '__main__':
+    keyboard.go()


### PR DESCRIPTION
The first row works for some reason, that is A and B are emitted appropriately when the buttons are pushed .
The second row for C and D doesn't work at all.
I made some example PR which can successfully scan the matrix, if my method is correct (https://github.com/timfenney/kmk_firmware/pull/2). However it is not necessary since I reproduced this behaviour with a new Pi Pico board fresh from the package (after flashing Circuitpython again), and attempting to simply bridge the connectors.
Adafruit CircuitPython 8.0.0-alpha.1-53-g02c804c2d on 2022-07-14; Raspberry Pi Pico with rp2040
Board ID:raspberry_pi_pico
![Screenshot from 2022-07-15 10-36-14](https://user-images.githubusercontent.com/654400/179299352-9768f3c4-97f1-4117-8ff0-43e7c8a50dd5.png)

